### PR TITLE
Support sti

### DIFF
--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -122,7 +122,7 @@ module Elasticsearch
             def concrete_klass(document)
               concrete_klass = klass
               if document['_source'].is_a?(Hash)
-                document_type_const_name = document['_source']['type'].to_s.capitalize
+                document_type_const_name = document['_source']['type'].to_s
                 if document_type_const_name.present? && Object.const_defined?(document_type_const_name)
                   concrete_klass = Object.const_get(document_type_const_name)
                 end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -132,7 +132,7 @@ module Elasticsearch
               # safe_constantize returns Object for blank. So we need to check this ourselves
               return klass if classname.blank?
               concrete_class = ActiveSupport::Dependencies.safe_constantize(classname)
-              return concrete_class if ActiveSupport::DescendantsTracker.descendants(klass).include?(concrete_class)
+              return concrete_class if concrete_class && concrete_class < klass
               klass
             end
           end

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -120,14 +120,11 @@ module Elasticsearch
             end 
             
             def concrete_klass(document)
+              return klass unless document['_source'].is_a?(Hash)
               concrete_klass = klass
-              if document['_source'].is_a?(Hash)
-                document_type_const_name = document['_source']['type'].to_s
-                if document_type_const_name.present? && Object.const_defined?(document_type_const_name)
-                  concrete_klass = Object.const_get(document_type_const_name)
-                end
-              end
-              return concrete_klass
+              document_type_const_name = document['_source']['type'].to_s
+              return klass if document_type_const_name.blank?
+              ActiveSupport::Dependencies.safe_constantize(document_type_const_name) || klass
             end
           end
 

--- a/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
+++ b/elasticsearch-persistence/lib/elasticsearch/persistence/model.rb
@@ -100,7 +100,7 @@ module Elasticsearch
             end
 
             def deserialize(document)
-              object = klass.new document['_source']
+              object = concrete_klass(document).new document['_source']
 
               # Set the meta attributes when fetching the document from Elasticsearch
               #
@@ -117,6 +117,17 @@ module Elasticsearch
 
               object.instance_variable_set(:@persisted, true)
               object
+            end 
+            
+            def concrete_klass(document)
+              concrete_klass = klass
+              if document['_source'].is_a?(Hash)
+                document_type_const_name = document['_source']['type'].to_s.capitalize
+                if document_type_const_name.present? && Object.const_defined?(document_type_const_name)
+                  concrete_klass = Object.const_get(document_type_const_name)
+                end
+              end
+              return concrete_klass
             end
           end
 

--- a/elasticsearch-persistence/test/integration/model/model_basic_test.rb
+++ b/elasticsearch-persistence/test/integration/model/model_basic_test.rb
@@ -20,6 +20,7 @@ module Elasticsearch
                     raw:  { type: 'string', analyzer: 'keyword' }
                   } }
 
+        attribute :type,       String
         attribute :birthday,   Date
         attribute :department, String
         attribute :salary,     Integer
@@ -227,7 +228,17 @@ module Elasticsearch
           assert_contains @results, 'John 1'
         end
       end
-
+      context "with sti" do
+        class ::Worker < ::Person
+          document_type 'human_being'
+          index_name 'people'
+        end
+        should "return a concrete class if a class type is stored" do
+          Worker.create name: "John", type: "worker"
+          Person.gateway.refresh_index!
+          assert_equal Worker, Person.all.first.class
+        end
+      end
     end
   end
 end

--- a/elasticsearch-persistence/test/integration/model/model_basic_test.rb
+++ b/elasticsearch-persistence/test/integration/model/model_basic_test.rb
@@ -234,7 +234,7 @@ module Elasticsearch
           index_name 'people'
         end
         should "return a concrete class if a class type is stored" do
-          Worker.create name: "John", type: "worker"
+          Worker.create name: "John", type: "Worker"
           Person.gateway.refresh_index!
           assert_equal Worker, Person.all.first.class
         end

--- a/elasticsearch-persistence/test/integration/model/model_basic_test.rb
+++ b/elasticsearch-persistence/test/integration/model/model_basic_test.rb
@@ -233,10 +233,30 @@ module Elasticsearch
           document_type 'human_being'
           index_name 'people'
         end
-        should "return a concrete class if a class type is stored" do
+
+        should "return a concrete class if 'type' is a subclass of the base class" do
           Worker.create name: "John", type: "Worker"
           Person.gateway.refresh_index!
           assert_equal Worker, Person.all.first.class
+        end
+
+        should "return a concrete class if 'type' is not a subclass of the base class" do
+          class ::Pilot  ; end
+          Worker.create name: "John", type: "Pilot"
+          Person.gateway.refresh_index!
+          assert_equal Person, Person.all.first.class
+        end
+
+        should "return the base class if 'type' is not stored" do
+          Worker.create name: "John"
+          Person.gateway.refresh_index!
+          assert_equal Person, Person.all.first.class
+        end
+
+        should "return the base class if 'type' is not a class" do
+          Worker.create name: "John", type: "a_type_of_notification"
+          Person.gateway.refresh_index!
+          assert_equal Person, Person.all.first.class
         end
       end
     end


### PR DESCRIPTION
This allows you to do `Person.all` and get a mix of different subclasses of `Person`.

Caveats:

It would be nice to instead of adding `type` you could use `document_type`, but then if you create a `Worker`, it won't be found when doing `Person.all`.

For now you had to add yourself the `type`, which should be the class name.

Note also that the subclasses need to be loaded. Otherwise the subclass name won't be found:
```
2.3.1 :002 > Person.subclasses
 => []
2.3.1 :004 > Worker
 => Worker
2.3.1 :002 > Person.subclasses
 => [Worker]
```